### PR TITLE
Feature/auto close result sets

### DIFF
--- a/transaction/src/main/java/org/irenical/drowsy/transaction/DrowsyConnection.java
+++ b/transaction/src/main/java/org/irenical/drowsy/transaction/DrowsyConnection.java
@@ -1,5 +1,8 @@
 package org.irenical.drowsy.transaction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.lang.reflect.InvocationHandler;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -9,9 +12,6 @@ import java.sql.SQLException;
 import java.sql.Statement;
 import java.util.Collection;
 import java.util.LinkedList;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 public class DrowsyConnection implements InvocationHandler {
 
@@ -28,12 +28,12 @@ public class DrowsyConnection implements InvocationHandler {
 
   public static Connection wrap(Connection connection) {
     if (Proxy.isProxyClass(connection.getClass())
-        && Proxy.getInvocationHandler(connection) instanceof DrowsyConnection) {
+      && Proxy.getInvocationHandler(connection) instanceof DrowsyConnection) {
       return connection;
     }
     DrowsyConnection proxy = new DrowsyConnection(connection);
     return (Connection) Proxy.newProxyInstance(DrowsyConnection.class.getClassLoader(),
-        new Class[] { Connection.class }, proxy);
+      new Class[]{Connection.class}, proxy);
   }
 
   @Override
@@ -42,9 +42,12 @@ public class DrowsyConnection implements InvocationHandler {
       if ("close".equals(method.getName())) {
         for (Statement stmt : statements) {
           try {
-            stmt.close();
+            if (!stmt.isClosed()) {
+              LOG.warn("Statement{} was left open. Closing from DrowsyConnection proxy", stmt);
+              stmt.close();
+            }
           } catch (Exception e) {
-            LOG.warn("Ignoring error closing statement " + stmt + ". Cause: " + e.getMessage());
+            LOG.error("Ignoring error closing statement {}", stmt, e);
           }
         }
         statements.clear();

--- a/transaction/src/main/java/org/irenical/drowsy/transaction/DrowsyConnection.java
+++ b/transaction/src/main/java/org/irenical/drowsy/transaction/DrowsyConnection.java
@@ -53,8 +53,9 @@ public class DrowsyConnection implements InvocationHandler {
         statements.clear();
       }
 
-      final Object ret = method.invoke(connection, args);
+      Object ret = method.invoke(connection, args);
       if (ret instanceof Statement) {
+        ret = DrowsyStatement.wrap((Statement) ret);
         statements.add((Statement) ret);
       }
 

--- a/transaction/src/main/java/org/irenical/drowsy/transaction/DrowsyStatement.java
+++ b/transaction/src/main/java/org/irenical/drowsy/transaction/DrowsyStatement.java
@@ -1,7 +1,81 @@
 package org.irenical.drowsy.transaction;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationHandler;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Proxy;
+import java.sql.CallableStatement;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.Collection;
+import java.util.HashSet;
+
 /**
  * Created by gluiz on 06/04/2017.
  */
-public class IMGStatement {
+public final class DrowsyStatement implements InvocationHandler {
+  private static final Logger LOG = LoggerFactory.getLogger(DrowsyStatement.class);
+  private final Collection<ResultSet> resultSets;
+  private final Statement statement;
+
+  private DrowsyStatement(Statement statement) {
+    this.statement = statement;
+    this.resultSets = new HashSet<>();
+  }
+
+  public static Statement wrap(Statement statement) {
+    if (Proxy.isProxyClass(statement.getClass())
+      && Proxy.getInvocationHandler(statement) instanceof DrowsyStatement) {
+      return statement;
+    }
+    DrowsyStatement proxy = new DrowsyStatement(statement);
+
+    if (statement instanceof CallableStatement) {
+      return (CallableStatement) Proxy.newProxyInstance(DrowsyStatement.class.getClassLoader(),
+        new Class[]{CallableStatement.class}, proxy);
+    }
+    if (statement instanceof PreparedStatement) {
+      return (PreparedStatement) Proxy.newProxyInstance(DrowsyStatement.class.getClassLoader(),
+        new Class[]{PreparedStatement.class}, proxy);
+    }
+    return (Statement) Proxy.newProxyInstance(DrowsyStatement.class.getClassLoader(),
+      new Class[]{Statement.class}, proxy);
+  }
+
+  @Override
+  public Object invoke(Object proxy, Method method, Object[] args) throws Throwable {
+    try {
+      if ("close".equals(method.getName())) {
+        for (ResultSet rst : resultSets) {
+          try {
+            if (!rst.isClosed()) {
+              LOG.warn("Result set {} was left open. Closing from DrowsyStatement proxy", rst);
+              rst.close();
+            }
+          } catch (Exception e) {
+            LOG.error("Ignoring error closing result set {}", rst, e);
+          }
+        }
+        resultSets.clear();
+      }
+
+      final Object ret = method.invoke(statement, args);
+      if (ret instanceof ResultSet) {
+        resultSets.add((ResultSet) ret);
+      }
+
+      return ret;
+    } catch (InvocationTargetException ex) {
+      if (ex.getCause() instanceof SQLException) {
+        throw ex.getCause();
+      } else {
+        throw ex;
+      }
+    }
+  }
 }

--- a/transaction/src/main/java/org/irenical/drowsy/transaction/DrowsyStatement.java
+++ b/transaction/src/main/java/org/irenical/drowsy/transaction/DrowsyStatement.java
@@ -1,0 +1,7 @@
+package org.irenical.drowsy.transaction;
+
+/**
+ * Created by gluiz on 06/04/2017.
+ */
+public class IMGStatement {
+}


### PR DESCRIPTION
doesn't throw away stacktraces anymore
ensures implementation independent closing of child resources (namely ResultSets when the Statement is closed)
raised the log level of exceptions during closing database resources (from WARN to ERROR)
added logging statement when closing resources when they were left open (WARN) as this is usually a development mistake that should be corrected